### PR TITLE
Add a new '/' delimiter

### DIFF
--- a/fixtures.csv
+++ b/fixtures.csv
@@ -496,3 +496,28 @@ Qualcomm Confidential and Proprietary"
 "Questionable extension field!\x00RFC 5639 curve over a 160 bit prime
 field\x00RFC 5639 curve over a 192 bit prime field","Questionable extension field!RFC 5639 curve over a 160 bit prime
 fieldRFC 5639 curve over a 192 bit prime field"
+"/ Copyright 2006, Google Inc.
+/ All rights reserved.
+/
+/ Redistribution and use in source and binary forms, with or without
+/ modification, are permitted provided that the following conditions are
+/ met:
+/
+/     * Redistributions of source code must retain the above copyright
+/ notice, this list of conditions and the following disclaimer.
+/     * Redistributions in binary form must reproduce the above
+/ copyright notice, this list of conditions and the following disclaimer
+/ in the documentation and/or other materials provided with the
+/ distribution.","Copyright 2006, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution."

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,7 +15,7 @@ function loadFixtures(): [string, string][] {
 
 describe('Normalize License Text', () => {
   it('should normalize license text with the default delimiters', () => {
-    expect.assertions(32); // entries in csv
+    expect.assertions(33); // entries in csv
     const fixtures = loadFixtures();
     fixtures.forEach(([raw, normalized]) => {
       expect(normalizeLicenseText(raw)).toEqual(normalized);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const DEFAULT_LEADING_DELIMITERS: Delimiter[] = [
   '*',
   '-',
   '@echo',
+  '/',
 ];
 const DEFAULT_BULLET_DELIMITERS: Delimiter[] = ['*', '-'];
 const DEFAULT_TRAILING_DELIMITERS: Delimiter[] = ['*/', '*;', '*'];


### PR DESCRIPTION
# Description

This PR adds a new delimiter `/`.

## Steps to Test or Reproduce
Input
```
/ Copyright 2006, Google Inc.
/ All rights reserved.
/
/ Redistribution and use in source and binary forms, with or without
/ modification, are permitted provided that the following conditions are
/ met:
/
/     * Redistributions of source code must retain the above copyright
/ notice, this list of conditions and the following disclaimer.
/     * Redistributions in binary form must reproduce the above
/ copyright notice, this list of conditions and the following disclaimer
/ in the documentation and/or other materials provided with the
/ distribution.
```
Output
```
Copyright 2006, Google Inc.
All rights reserved.

Redistribution and use in source and binary forms, with or without
modification, are permitted provided that the following conditions are
met:

Redistributions of source code must retain the above copyright
notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above
copyright notice, this list of conditions and the following disclaimer
in the documentation and/or other materials provided with the
distribution.
```
